### PR TITLE
refactor regulation list

### DIFF
--- a/src/pyb2b/types/generated/flow.py
+++ b/src/pyb2b/types/generated/flow.py
@@ -149,6 +149,16 @@ class RegulationCause(TypedDict, total=False):
     iataDelayCode: str
 
 
+class RegulationListRequest(common.Request, common.DateTimeMinutePeriod): ...
+
+
+class RegulationListReplyData(TypedDict, total=False): ...
+
+
+class RegulationListReply(common.Reply):
+    data: RegulationListReplyData
+
+
 HotspotSeverity = Literal["HIGH", "MEDIUM", "LOW"]
 
 HotspotStatus = Literal["DRAFT", "ACTIVE", "SOLVED", "ACCEPTABLE"]


### PR DESCRIPTION
I refactored the regulation list following the flight requests.
I think there is a few work left on the typing side.
It also removes the build_df method which I find very useful so it might be interesting to keep it. I wanted to double check with you for the architecture of the package if we want to keep it, where it should be placed.